### PR TITLE
add env check for username

### DIFF
--- a/src/pimUtils.go
+++ b/src/pimUtils.go
@@ -3,6 +3,7 @@ package src
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"syscall"
 	"time"
 
@@ -23,11 +24,14 @@ type PimOptions struct {
 }
 
 func promptForCredentials() (string, string, error) {
-	var username, password string
-	fmt.Print("Username: ")
-	_, err := fmt.Scanln(&username)
-	if err != nil {
-		return "", "", err
+	username := os.Getenv("EZPIM_USERNAME")
+	var password string
+	if len(username) == 0 {
+		fmt.Print("Username: ")
+		_, err := fmt.Scanln(&username)
+		if err != nil {
+			return "", "", err
+		}
 	}
 	fmt.Print("Password: ")
 	bytePassword, err := terminal.ReadPassword(syscall.Stdin)


### PR DESCRIPTION
This pull request updates the credential prompt logic in `src/pimUtils.go` to support reading the username from an environment variable, improving automation and usability.

Credential input improvements:

* [`src/pimUtils.go`](diffhunk://#diff-489ae70a0b4e667caf3193f48d6b803a3b958f5a33e75a734990f61dc161f9fbL26-R35): Modified the `promptForCredentials` function to first check for the `EZPIM_USERNAME` environment variable, and only prompt for the username interactively if the variable is not set.
* [`src/pimUtils.go`](diffhunk://#diff-489ae70a0b4e667caf3193f48d6b803a3b958f5a33e75a734990f61dc161f9fbR6): Added an import for the `os` package to enable reading environment variables.