### PR TITLE
Headless feature

### DIFF
--- a/azuClient/token.go
+++ b/azuClient/token.go
@@ -1,6 +1,7 @@
 package azuClient
 
 import (
+	"app/log"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -32,8 +33,12 @@ func (apt *AzurePimToken) ComputeAdditionalFields() error {
 		return nil
 	}
 
+	logger := log.InitializeLogger()
+
 	// Manually decode the JWT token to extract claims without signature verification
 	// Split the JWT into parts (header.payload.signature)
+	logger.WithPrefix("JWT").Info("Decoding JWT token...")
+	logger.WithPrefix("JWT").Infof("JWT token found: %s***", apt.Secret[:3])
 	parts := strings.Split(apt.Secret, ".")
 	if len(parts) != 3 {
 		return fmt.Errorf("invalid JWT format: expected 3 parts, got %d", len(parts))

--- a/cmd/activateCMD.go
+++ b/cmd/activateCMD.go
@@ -17,8 +17,14 @@ var activateC = &cobra.Command{
 		duration, _ := cmd.Flags().GetInt("duration")
 		reason, _ := cmd.Flags().GetString("reason")
 		interactive, _ := cmd.Flags().GetBool("interactive")
+		headless, _ := cmd.Flags().GetBool("headless")
+
+		if headless && interactive {
+			panic("Cannot use headless and interactive flags at the same time")
+		}
 
 		opts := src.ActivationOptions{
+			Headless:    headless,
 			Interactive: interactive,
 			Reason:      reason,
 			Duration:    duration,

--- a/cmd/activateCMD.go
+++ b/cmd/activateCMD.go
@@ -17,7 +17,7 @@ var activateC = &cobra.Command{
 		duration, _ := cmd.Flags().GetInt("duration")
 		reason, _ := cmd.Flags().GetString("reason")
 		interactive, _ := cmd.Flags().GetBool("interactive")
-		headless, _ := cmd.Flags().GetBool("headless")
+		headless, _ := cmd.Flags().GetBool("browserHeadless")
 
 		if headless && interactive {
 			panic("Cannot use headless and interactive flags at the same time")

--- a/cmd/activateCMD.go
+++ b/cmd/activateCMD.go
@@ -4,6 +4,7 @@ Copyright © 2025 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"app/log"
 	"app/src"
 
 	"github.com/spf13/cobra"
@@ -14,13 +15,14 @@ var activateC = &cobra.Command{
 	Short: "Activate PIM for groups",
 	Long:  `Activate PIM for groups`,
 	Run: func(cmd *cobra.Command, args []string) {
+		logger := log.InitializeLogger()
 		duration, _ := cmd.Flags().GetInt("duration")
 		reason, _ := cmd.Flags().GetString("reason")
 		interactive, _ := cmd.Flags().GetBool("interactive")
-		headless, _ := cmd.Flags().GetBool("browserHeadless")
+		headless, _ := cmd.Flags().GetBool("browser-headless")
 
 		if headless && interactive {
-			panic("Cannot use headless and interactive flags at the same time")
+			logger.Fatal("Cannot use headless and interactive flags at the same time")
 		}
 
 		opts := src.ActivationOptions{

--- a/cmd/listCMD.go
+++ b/cmd/listCMD.go
@@ -4,6 +4,7 @@ Copyright © 2025 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"app/log"
 	"app/src"
 
 	"github.com/spf13/cobra"
@@ -15,10 +16,11 @@ var listCmd = &cobra.Command{
 	Short: "List all groups available to Azure PIM",
 	Long:  `List all groups available to Azure PIM`,
 	Run: func(cmd *cobra.Command, args []string) {
+		logger := log.InitializeLogger()
 		interactive, _ := cmd.Flags().GetBool("interactive")
-		headless, _ := cmd.Flags().GetBool("browserHeadless")
+		headless, _ := cmd.Flags().GetBool("browser-headless")
 		if headless && interactive {
-			panic("Cannot use headless and interactive flags at the same time")
+			logger.Fatal("Cannot use headless and interactive flags at the same time")
 		}
 		src.ListGroups(src.ListOpts{Headless: headless, Interactive: interactive})
 	},

--- a/cmd/listCMD.go
+++ b/cmd/listCMD.go
@@ -16,7 +16,11 @@ var listCmd = &cobra.Command{
 	Long:  `List all groups available to Azure PIM`,
 	Run: func(cmd *cobra.Command, args []string) {
 		interactive, _ := cmd.Flags().GetBool("interactive")
-		src.ListGroups(interactive)
+		headless, _ := cmd.Flags().GetBool("headless")
+		if headless && interactive {
+			panic("Cannot use headless and interactive flags at the same time")
+		}
+		src.ListGroups(src.ListOpts{Headless: headless, Interactive: interactive})
 	},
 }
 

--- a/cmd/listCMD.go
+++ b/cmd/listCMD.go
@@ -16,7 +16,7 @@ var listCmd = &cobra.Command{
 	Long:  `List all groups available to Azure PIM`,
 	Run: func(cmd *cobra.Command, args []string) {
 		interactive, _ := cmd.Flags().GetBool("interactive")
-		headless, _ := cmd.Flags().GetBool("headless")
+		headless, _ := cmd.Flags().GetBool("browserHeadless")
 		if headless && interactive {
 			panic("Cannot use headless and interactive flags at the same time")
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,5 +42,5 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	rootCmd.Flags().BoolP("browserHeadless", "h", false, "browser headless, only use if you want the browser to be totally headless. All information will be taken via cli")
+	rootCmd.Flags().BoolP("browserHeadless", "b", false, "browser headless, only use if you want the browser to be totally headless. All information will be taken via cli")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,5 +42,5 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	rootCmd.Flags().BoolP("browserHeadless", "b", false, "browser headless, only use if you want the browser to be totally headless. All information will be taken via cli")
+	rootCmd.PersistentFlags().BoolP("browserHeadless", "b", false, "browser headless, only use if you want the browser to be totally headless. All information will be taken via cli")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,5 +42,8 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	rootCmd.PersistentFlags().BoolP("browserHeadless", "b", false, "browser headless, only use if you want the browser to be totally headless. All information will be taken via cli")
+	rootCmd.PersistentFlags().BoolP(
+		"browser-headless", "b", false,
+		"browser headless, only use if you want the browser to be totally headless. All information will be taken via cli",
+	)
 }

--- a/src/activate.go
+++ b/src/activate.go
@@ -9,6 +9,7 @@ import (
 )
 
 type ActivationOptions struct {
+	Headless    bool
 	Interactive bool
 	Reason      string
 	Duration    int      // Duration in hours
@@ -17,7 +18,10 @@ type ActivationOptions struct {
 
 func ActivatePim(opts ActivationOptions) {
 	logger := log.InitializeLogger()
-	appSettings := Initialize(logger, opts.Interactive)
+	appSettings := Initialize(logger, InitOpts{
+		Interactive: opts.Interactive,
+		Headless:    opts.Headless,
+	})
 	azureClient := azuClient.AzureClient{
 		AzurePimToken: appSettings.Session.AZPimToken,
 	}

--- a/src/list.go
+++ b/src/list.go
@@ -6,9 +6,17 @@ import (
 	"app/log"
 )
 
-func ListGroups(interactive bool) {
+type ListOpts struct {
+	Interactive bool
+	Headless    bool
+}
+
+func ListGroups(opts ListOpts) {
 	logger := log.InitializeLogger()
-	appSettings := Initialize(logger, interactive)
+	appSettings := Initialize(logger, InitOpts{
+		Interactive: opts.Interactive,
+		Headless:    opts.Headless,
+	})
 	client := azuClient.AzureClient{
 		AzurePimToken: appSettings.Session.AZPimToken,
 	}

--- a/src/pimUtils.go
+++ b/src/pimUtils.go
@@ -8,10 +8,14 @@ import (
 	"time"
 
 	"app/azuClient"
+
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/playwright-community/playwright-go"
 )
+
+const userNameTextBox = "//*[@id=\"i0116\"]"
+const userNameSubmitButton = "//*[@id=\"idSIButton9\"]"
 
 type PimOptions struct {
 	Headless        bool
@@ -40,6 +44,10 @@ func promptForCredentials() (string, string, error) {
 	}
 	password = string(bytePassword)
 	return username, password, nil
+}
+
+func handle2FA(page playwright.Page) error {
+	return nil
 }
 
 func LaunchBrowserToGetToken(appSettings AppSettings, opts PimOptions) {
@@ -94,13 +102,10 @@ func LaunchBrowserToGetToken(appSettings AppSettings, opts PimOptions) {
 	}
 
 	if opts.Username != "" && opts.Password != "" {
-		usernameLocator := page.GetByPlaceholder("Email, phone, or Skype")
-		err := usernameLocator.Fill(opts.Username)
-		if err != nil {
-			panic("could not fill email: " + err.Error())
+		if err = page.Locator(userNameTextBox).Fill(opts.Username); err != nil {
+			panic(err)
 		}
-		err = usernameLocator.Press("Enter")
-		if err != nil {
+		if err = page.Locator(userNameSubmitButton).Click(); err != nil {
 			panic("could not press email: " + err.Error())
 		}
 		passwordLocator := page.GetByPlaceholder("Password")
@@ -111,6 +116,10 @@ func LaunchBrowserToGetToken(appSettings AppSettings, opts PimOptions) {
 		err = passwordLocator.Press("Enter")
 		if err != nil {
 			panic("could not press password: " + err.Error())
+		}
+
+		if opts.Headless {
+			err = handle2FA(page)
 		}
 	}
 

--- a/src/settings.go
+++ b/src/settings.go
@@ -19,6 +19,11 @@ type AppSettings struct {
 	Session    SessionConfig
 }
 
+type InitOpts struct {
+	Interactive bool
+	Headless    bool
+}
+
 func (a *AppSettings) SaveSettings() {
 	err := MarshalAndWriteFileContents(a.ConfigFile, a.Session)
 	if err != nil {
@@ -66,7 +71,7 @@ func preflight() {
 	}
 }
 
-func Initialize(logger *log.Logger, interactiveMode bool) AppSettings {
+func Initialize(logger *log.Logger, opts InitOpts) AppSettings {
 	preflight()
 	appSettings := loadSessionFromFile()
 	now := time.Now().Unix()
@@ -78,7 +83,7 @@ func Initialize(logger *log.Logger, interactiveMode bool) AppSettings {
 		logger.Info("Token expired. Please login to get new token")
 		logger.Info("Launching browser to get new token")
 		var username, password string
-		if !interactiveMode {
+		if !opts.Interactive {
 			username, password, err = promptForCredentials()
 		}
 		if err != nil {


### PR DESCRIPTION
Adds ability to do flow completely headless with `-b` flag for `browserHeadless`

Note this cannot be used in conjunction with `-i` flag since interactive means you want the browser to show up

I made the denotation between for this since not everyone has regular auth code and I'm not sure at this time how to do fully headless for that auth flow with the msft auth app